### PR TITLE
Fix version format

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-clangd-cdtcloud",
     "displayName": "vscode-clangd-cdtcloud",
     "description": "Fork of the clangd VS Code extension for C/C++ completion, navigation, and insights, plus better support for multiple projects in a single workspace.",
-    "version": "0.1.26+1",
+    "version": "0.12.26-1",
     "publisher": "eclipse-cdt",
     "license": "MIT",
     "homepage": "https://eclipse.dev/cdt-cloud",


### PR DESCRIPTION
The VSCode marketplace does not allow `+` modifers in versions -> Change version to 0.1.26.1